### PR TITLE
Improved enableLed usage

### DIFF
--- a/examples/analogComp_enableInterrupt/analogComp_enableInterrupt.ino
+++ b/examples/analogComp_enableInterrupt/analogComp_enableInterrupt.ino
@@ -34,7 +34,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 //global variables
 const byte LED13 = 13; //set the output LED
-boolean enableLed = false; //used to check if the interrupt has raised
+volatile boolean enableLed = false; //used to check if the interrupt has raised
 
 //let's set up the hardware
 void setup() {


### PR DESCRIPTION
enableLed should be declared as volatile, as it is modified within an interrupt service routine - see https://www.arduino.cc/en/Reference/Volatile for why