### PR TITLE
Added read comparator method

### DIFF
--- a/analogComp.cpp
+++ b/analogComp.cpp
@@ -214,6 +214,12 @@ void analogComp::enableInterrupt(void (*tempUserFunction)(void), uint8_t tempMod
     _interruptEnabled = 1;
 }
 
+// Vout = 1 when Vin0 > Vin1
+// Vout = 0 when Vin0 < Vin1
+bool analogComp::readComparator(){
+    return ACSR & (1<<ACO);
+}
+
 
 //disable the interrupt on comparations
 void analogComp::disableInterrupt(void) {

--- a/analogComp.h
+++ b/analogComp.h
@@ -86,6 +86,7 @@ class analogComp {
 		//analogComp();
         uint8_t setOn(uint8_t = AIN0, uint8_t = AIN1);
         void setOff(void);
+        bool readComparator();
         void enableInterrupt(void (*)(void), uint8_t tempMode = CHANGE);
         void disableInterrupt(void);
         uint8_t waitComp(unsigned long = 0);


### PR DESCRIPTION
When using an interrupt to detect change, it's sometimes necessary to find whether it was rising or falling within the callback function. This method makes that a bit easier.